### PR TITLE
Potential fix for code scanning alert no. 8: Shell command built from environment values

### DIFF
--- a/scripts/create-admin.js
+++ b/scripts/create-admin.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const readline = require('readline');
 const path = require('path');
 
@@ -26,11 +26,14 @@ async function main() {
 
     // Build and run the TypeScript file
     const scriptPath = path.join(__dirname, '..', 'src', 'scripts', 'createAdmin.ts');
-    const command = `
-      ts-node -r tsconfig-paths/register "${scriptPath}" "${email}" "${password}"
-    `;
+    const args = [
+      '-r', 'tsconfig-paths/register',
+      scriptPath,
+      email,
+      password
+    ];
 
-    execSync(command, { stdio: 'inherit' });
+    execFileSync('ts-node', args, { stdio: 'inherit' });
     
     console.log('\nAdmin user created successfully!');
     console.log('You can now log in with these credentials at /login');


### PR DESCRIPTION
Potential fix for [https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/8](https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/8)

To fix the problem, we should avoid constructing a shell command string and passing it to `execSync`, which invokes a shell. Instead, we should use `execFileSync` (or `spawnSync`) from the `child_process` module, which allows us to specify the command and its arguments as separate parameters. This way, the arguments are passed directly to the executable without shell interpretation, preventing issues with spaces or special characters in paths or user input.

Specifically, in `scripts/create-admin.js`, we should:
- Replace the construction of the `command` string with an array of arguments.
- Use `execFileSync` instead of `execSync`, passing the command (`ts-node`) and the arguments array.
- Ensure that the required import for `execFileSync` is present.

No other changes are needed, and the script's functionality will remain the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
