### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "vaul": "^0.9.3",
     "vitest": "^3.1.4",
     "zod": "^3.23.8",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/src/components/StoryBibleDrawer.tsx
+++ b/src/components/StoryBibleDrawer.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
+import sanitizeHtml from 'sanitize-html';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -175,7 +176,7 @@ export const StoryBibleDrawer: React.FC<StoryBibleDrawerProps> = ({ projectId })
       {entry.description && (
         <CardContent className="pt-0">
           <p className="text-xs text-muted-foreground line-clamp-2">
-            {entry.description.replace(/<[^>]*>/g, '').substring(0, 80)}
+            {sanitizeHtml(entry.description, { allowedTags: [], allowedAttributes: {} }).substring(0, 80)}
             {entry.description.length > 80 && '...'}
           </p>
         </CardContent>


### PR DESCRIPTION
Potential fix for [https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/1](https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/1)

The best way to fix this problem is to use a well-tested HTML sanitization library, such as `sanitize-html`, to remove all potentially dangerous HTML from `entry.description`. This approach is more robust than using a regular expression, as it handles edge cases, nested tags, and script injection attempts. Since we can only edit the code in this file, we will import `sanitize-html` at the top and use it to sanitize `entry.description` before rendering. This change should be made on line 178, replacing the current `.replace(/<[^>]*>/g, '')` with a call to `sanitizeHtml(entry.description, { allowedTags: [], allowedAttributes: {} })`, which strips all HTML tags and attributes.

**Required changes:**
- Add an import for `sanitize-html` at the top of the file.
- Replace the `.replace(/<[^>]*>/g, '')` call with `sanitizeHtml(entry.description, { allowedTags: [], allowedAttributes: {} })` on line 178.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
