### PR TITLE
Potential fix for code scanning alert no. 7: Clear text storage of sensitive information

### DIFF
--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -219,14 +219,8 @@ export class SecureStorage {
   }
   
   async initialize(): Promise<void> {
-    // Try to get existing password from sessionStorage (temporary session-based)
-    this.password = sessionStorage.getItem('enc_session_key');
-    
-    if (!this.password) {
-      // Generate new password for this session
-      this.password = generateEncryptionPassword();
-      sessionStorage.setItem('enc_session_key', this.password);
-    }
+    // Always generate a new password for this session and keep it only in memory
+    this.password = generateEncryptionPassword();
   }
   
   async storeApiKey(service: string, apiKey: string): Promise<void> {


### PR DESCRIPTION
Potential fix for [https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/7](https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/7)

To fix the problem, we should avoid storing the encryption password in clear text in sessionStorage. Instead, we can use a less persistent, more secure mechanism for keeping the password in memory only (e.g., as a private field in the singleton instance), and never write it to sessionStorage or any other persistent storage. If the password must persist across page reloads, consider using a user-provided secret (e.g., a passphrase) or a secure mechanism such as the Web Crypto API's `CryptoKey` objects, which are not directly accessible as strings and are not serializable.

**Best fix for this code:**  
- Remove all code that stores or retrieves the encryption password from sessionStorage.
- Keep the password only in memory (as a private field of the `SecureStorage` instance).
- If the user reloads the page, the password will be lost and a new one will be generated, which is a tradeoff for security.
- Update the `initialize` method to always generate a new password for each session, and do not attempt to persist it.

**Required changes:**  
- Remove lines that read from or write to sessionStorage for the password (lines 223 and 228).
- Update comments to reflect the new behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
