### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/src/utils/highlighting.ts
+++ b/src/utils/highlighting.ts
@@ -139,7 +139,7 @@ const clearHighlights = (quill: any, start: number, length: number) => {
 };
 
 const createTooltipContent = (entry: StoryBibleEntry): string => {
-  const description = entry.description.replace(/<[^>]*>/g, ''); // Strip HTML
+  const description = entry.description;
   const shortDescription = description.length > 200 
     ? description.substring(0, 197) + '...' 
     : description;


### PR DESCRIPTION
Potential fix for [https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/4](https://github.com/BlvckboiVu/story-forge-nucleus/security/code-scanning/4)

The best way to fix this problem is to avoid using a regular expression to strip HTML tags, as this is error-prone and incomplete. Instead, rely entirely on a well-tested HTML sanitization library (such as `sanitize-html`) to clean the input. In this case, remove the `.replace(/<[^>]*>/g, '')` call and pass the raw `entry.description` to the sanitizer. This change should be made in the `createTooltipContent` function in `src/utils/highlighting.ts`, specifically on line 142. No new imports are needed if `sanitizeHtml` is already imported and is a robust library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
